### PR TITLE
Change gotoXY() to use the LCD_COMMAND macro.

### DIFF
--- a/Firmware/Nokia_5110_Arduino_Example/Nokia_5110_Arduino_Example.ino
+++ b/Firmware/Nokia_5110_Arduino_Example/Nokia_5110_Arduino_Example.ino
@@ -263,8 +263,8 @@ void loop(void) {
 }
 
 void gotoXY(int x, int y) {
-  LCDWrite(0, 0x80 | x);  // Column.
-  LCDWrite(0, 0x40 | y);  // Row.  ?
+  LCDWrite(LCD_COMMAND, 0x80 | x);  // Column.
+  LCDWrite(LCD_COMMAND, 0x40 | y);  // Row.  ?
 }
 
 //This takes a large array of bits and sends them to the LCD


### PR DESCRIPTION
gotoXY() used magic number 0 instead of LCD_COMMAND macro.
